### PR TITLE
F# Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For performance and convenience:
  - `IFormattable` and `ISpanFormattable` allow `Option` and `Result` to efficiently format their content.
  - `Option` and `Result` can be efficiently converted to `ReadOnlySpan<T>` or `IEnumerable<T>` for easier interop with existing code.
  - Convenient extension methods for working with dictionaries (`GetValueOrNone`), collections (`FirstOrNone`), enums (`Option.ParseEnum`) and more.
+ - Supports explicit conversion to and from the F# Option, ValueOption, and Result types for easy interop.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ Option<int> ex1 = Option.Some(42);
 Option<int> ex2 = 42.Some();
 Option<int> ex3 = Option<int>.None;
 Option<int> ex4 = Option.None<int>();
+Option<int> ex5 = default; // equivalent to Option.None<int>()
 
 int? maybeNull = GetPossiblyNullInteger();
 Option<int> ex5 = Option.Create(maybeNull); // null turns into Option.None
 
-// Or you can use 'using static' for more concise/Rust-like syntax:
+// Or you can use 'using static' for more concise/F#/Rust-like syntax:
 using static RustyOptions.Option;
 
 var ex6 = Some(42);
@@ -73,7 +74,7 @@ Result<int, string> ex4 = Result.Err<int>("Oops.");
 Result<int, Exception> ex5 = Result.Err<int>(new Exception("Oops."));
 Result<int, MyCustomException> ex6 = Result.Err<int, MyCustomException(someException);
 
-// Or you can use 'using static' for more concise/Rust-like syntax:
+// Or you can use 'using static' for more concise/F#/Rust-like syntax:
 using static RustyOptions.Result;
 
 var ex7 = Ok(42);
@@ -137,6 +138,4 @@ For performance and convenience:
     - I think having distinct `Option` and `Result` types is more clear than having two different kinds of Option.
     - As of this writing, Optional hasn't been updated in five years.
   - What about F# `Option` and `Result`?
-    - C# code needs to take a dependency on `FSharp.Core` in order to use these types, and the F#-centric functions to work
-      with these types are awkward to use from C#. As a result, C# requires C#-specific types for this functionality.
-    - If there's demand, I can make a separate NuGet package that provides conversion between RustyOptions types and F# Option/Result. Open an issue if this is important to you!
+    - The `RustyOptions.FSharp` nuget package will allow you to convert between F# and RustyOptions types.

--- a/src/RustyOptions.FSharp.Tests/RustyOptions.FSharp.Tests.fsproj
+++ b/src/RustyOptions.FSharp.Tests/RustyOptions.FSharp.Tests.fsproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <ReleaseVersion>0.6.0</ReleaseVersion>
+    <AssemblyName>RustyOptions.FSharp.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RustyOptions.FSharp\RustyOptions.FSharp.fsproj" />
+    <ProjectReference Include="..\RustyOptions\RustyOptions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RustyOptions.FSharp.Tests/Tests.fs
+++ b/src/RustyOptions.FSharp.Tests/Tests.fs
@@ -1,0 +1,71 @@
+module Tests
+
+open Xunit
+open RustyOptions.FSharp
+
+[<Fact>]
+let ``Can convert with extension methods`` () =
+    let some = RustyOptions.Option.Some(42)
+    let none = RustyOptions.Option.None<int>()
+    let ok = RustyOptions.Result.Ok<int, string>(42)
+    let err = RustyOptions.Result.Err<int>("oops")
+
+    Assert.Equal(Some(42), some.AsFSharpOption());
+    Assert.Equal(None, none.AsFSharpOption());
+
+    Assert.Equal(ValueSome(42), some.AsFSharpValueOption());
+    Assert.Equal(ValueNone, none.AsFSharpValueOption());
+
+    Assert.Equal(Ok(42), ok.AsFSharpResult());
+    Assert.Equal(Error("oops"), err.AsFSharpResult());
+
+[<Fact>]
+let ``Can convert Option with module functions`` () =
+    let some = Some 42
+    let none = None
+
+    let rustySome = some |> Option.toRustyOption
+    let rustyNone = none |> Option.toRustyOption
+
+    let someConverted = rustySome |> Option.ofRustyOption
+    let noneConverted = rustyNone |> Option.ofRustyOption
+
+    Assert.Equal(RustyOptions.Option.Some(42), rustySome)
+    Assert.Equal(RustyOptions.Option.None<int>(), rustyNone)
+
+    Assert.Equal(some, someConverted)
+    Assert.Equal(none, noneConverted)
+
+[<Fact>]
+let ``Can convert ValueOption with module functions`` () =
+    let some = ValueSome 42
+    let none = ValueNone
+
+    let rustySome = some |> ValueOption.toRustyOption
+    let rustyNone = none |> ValueOption.toRustyOption
+
+    let someConverted = rustySome |> ValueOption.ofRustyOption
+    let noneConverted = rustyNone |> ValueOption.ofRustyOption
+
+    Assert.Equal(RustyOptions.Option.Some(42), rustySome)
+    Assert.Equal(RustyOptions.Option.None<int>(), rustyNone)
+
+    Assert.Equal(some, someConverted)
+    Assert.Equal(none, noneConverted)
+
+[<Fact>]
+let ``Can convert Result with module functions`` () =
+    let ok = Ok 42
+    let err = Error "oops"
+
+    let rustyOk = ok |> Result.toRustyResult
+    let rustyErr = err |> Result.toRustyResult
+
+    let okConverted = rustyOk |> Result.ofRustyResult
+    let errConverted = rustyErr |> Result.ofRustyResult
+
+    Assert.Equal(RustyOptions.Result.Ok<int>(42), rustyOk)
+    Assert.Equal(RustyOptions.Result.Err<int>("oops"), rustyErr)
+
+    Assert.Equal(ok, okConverted)
+    Assert.Equal(err, errConverted)

--- a/src/RustyOptions.FSharp.Tests/Tests.fs
+++ b/src/RustyOptions.FSharp.Tests/Tests.fs
@@ -69,3 +69,51 @@ let ``Can convert Result with module functions`` () =
 
     Assert.Equal(ok, okConverted)
     Assert.Equal(err, errConverted)
+
+#if NET7_0_OR_GREATER
+[<Fact>]
+let ``Can convert NumericOption with extension methods`` () =
+    let some = RustyOptions.NumericOption.Some(42)
+    let none = RustyOptions.NumericOption.None<int>()
+
+    Assert.Equal(Some(42), some.AsFSharpOption());
+    Assert.Equal(None, none.AsFSharpOption());
+
+    Assert.Equal(ValueSome(42), some.AsFSharpValueOption());
+    Assert.Equal(ValueNone, none.AsFSharpValueOption());
+
+[<Fact>]
+let ``Can convert NumericOption with module functions`` () =
+    let some = Some 42
+    let none = None
+
+    let rustySome = some |> Option.toRustyNumericOption
+    let rustyNone = none |> Option.toRustyNumericOption
+
+    let someConverted = rustySome |> Option.ofRustyNumericOption
+    let noneConverted = rustyNone |> Option.ofRustyNumericOption
+
+    Assert.Equal(RustyOptions.NumericOption.Some(42), rustySome)
+    Assert.Equal(RustyOptions.NumericOption.None<int>(), rustyNone)
+
+    Assert.Equal(some, someConverted)
+    Assert.Equal(none, noneConverted)
+
+[<Fact>]
+let ``Can convert NumericValueOption with module functions`` () =
+    let some = ValueSome 42
+    let none = ValueNone
+
+    let rustySome = some |> ValueOption.toRustyNumericOption
+    let rustyNone = none |> ValueOption.toRustyNumericOption
+
+    let someConverted = rustySome |> ValueOption.ofRustyNumericOption
+    let noneConverted = rustyNone |> ValueOption.ofRustyNumericOption
+
+    Assert.Equal(RustyOptions.NumericOption.Some(42), rustySome)
+    Assert.Equal(RustyOptions.NumericOption.None<int>(), rustyNone)
+
+    Assert.Equal(some, someConverted)
+    Assert.Equal(none, noneConverted)
+
+#endif

--- a/src/RustyOptions.FSharp/Library.fs
+++ b/src/RustyOptions.FSharp/Library.fs
@@ -29,6 +29,24 @@ module TypeExtensions =
             | (true, value) -> Ok value
             | _ -> Error(x.UnwrapErr())
 
+#if NET7_0_OR_GREATER
+    type RustyOptions.NumericOption<'a when 'a : struct and 'a :> System.ValueType and 'a : (new : unit -> 'a) and 'a :> System.Numerics.INumber<'a>> with
+
+        /// Converts a RustyOptions NumericOption into an F# ValueOption.
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        member x.AsFSharpValueOption() =
+            match x.IsSome() with
+            | (true, value) -> ValueSome value
+            | _ -> ValueNone
+
+        /// Converts a RustyOptions NumericOption into an F# Option.
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        member x.AsFSharpOption() =
+            match x.IsSome() with
+            | (true, value) -> Some(value)
+            | _ -> None
+#endif
+
 /// This module provides C# extension methods on RustyOptions types.
 [<Extension>]
 module CSharpTypeExtensions =
@@ -57,6 +75,28 @@ module CSharpTypeExtensions =
         | (true, value) -> Ok value
         | _ -> Error(x.UnwrapErr())
 
+#if NET7_0_OR_GREATER
+/// This module provides C# extension methods on RustyOptions numeric types.
+[<Extension>]
+module CSharpNumericTypeExtensions =
+
+    /// Converts a RustyOptions Option into an F# ValueOption.
+    [<Extension>]
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let AsFSharpValueOption(x: RustyOptions.NumericOption<'a>) =
+        match x.IsSome() with
+        | (true, value) -> ValueSome value
+        | _ -> ValueNone
+
+    /// Converts a RustyOptions Option into an F# ValueOption.
+    [<Extension>]
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let AsFSharpOption(x: RustyOptions.NumericOption<'a>) =
+        match x.IsSome() with
+        | (true, value) -> Some value
+        | _ -> None
+#endif
+
 module Option =
 
     /// Converts a RustyOptions Option into an F# Option.
@@ -73,6 +113,22 @@ module Option =
         | Some(value) -> RustyOptions.Option.Some(value)
         | _ -> RustyOptions.Option.None<'a>()
 
+#if NET7_0_OR_GREATER
+    /// Converts a RustyOptions Option into an F# Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let ofRustyNumericOption (x: RustyOptions.NumericOption<'a>) =
+        match x.IsSome() with
+        | (true, value) -> Some value
+        | _ -> None
+
+    /// Converts an F# Option into a RustyOptions Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let toRustyNumericOption (x: 'a option) =
+        match x with
+        | Some(value) -> RustyOptions.NumericOption.Some(value)
+        | _ -> RustyOptions.NumericOption.None<'a>()
+#endif
+
 module ValueOption =
 
     /// Converts a RustyOptions Option into an F# ValueOption.
@@ -88,6 +144,22 @@ module ValueOption =
         match x with
         | ValueSome(value) -> RustyOptions.Option.Some(value)
         | _ -> RustyOptions.Option.None<'a>()
+
+#if NET7_0_OR_GREATER
+    /// Converts a RustyOptions Option into an F# Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let ofRustyNumericOption (x: RustyOptions.NumericOption<'a>) =
+        match x.IsSome() with
+        | (true, value) -> ValueSome value
+        | _ -> ValueNone
+
+    /// Converts an F# Option into a RustyOptions Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let toRustyNumericOption (x: 'a voption) =
+        match x with
+        | ValueSome(value) -> RustyOptions.NumericOption.Some(value)
+        | _ -> RustyOptions.NumericOption.None<'a>()
+#endif
 
 module Result =
 

--- a/src/RustyOptions.FSharp/Library.fs
+++ b/src/RustyOptions.FSharp/Library.fs
@@ -1,0 +1,106 @@
+﻿namespace RustyOptions.FSharp
+
+open System.Runtime.CompilerServices
+
+/// This module provides F# extension methods on RustyOptions types.
+[<AutoOpen>]
+module TypeExtensions =
+
+    type RustyOptions.Option<'a> with
+        /// Converts a RustyOptions Option into an F# ValueOption.
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        member x.AsFSharpValueOption() =
+            match x.IsSome() with
+            | (true, value) -> ValueSome value
+            | _ -> ValueNone
+
+        /// Converts a RustyOptions Option into an F# Option.
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        member x.AsFSharpOption() =
+            match x.IsSome() with
+            | (true, value) -> Some(value)
+            | _ -> None
+
+    type RustyOptions.Result<'a, 'err> with
+        /// Converts a RustyOptions Result into an F# Result.
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        member x.AsFSharpResult() =
+            match x.IsOk() with
+            | (true, value) -> Ok value
+            | _ -> Error(x.UnwrapErr())
+
+/// This module provides C# extension methods on RustyOptions types.
+[<Extension>]
+module CSharpTypeExtensions =
+
+    /// Converts a RustyOptions Option into an F# ValueOption.
+    [<Extension>]
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let AsFSharpValueOption(x: RustyOptions.Option<'a>) =
+        match x.IsSome() with
+        | (true, value) -> ValueSome value
+        | _ -> ValueNone
+
+    /// Converts a RustyOptions Option into an F# ValueOption.
+    [<Extension>]
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let AsFSharpOption(x: RustyOptions.Option<'a>) =
+        match x.IsSome() with
+        | (true, value) -> Some value
+        | _ -> None
+
+    /// Converts a RustyOptions Result into an F# Result.
+    [<Extension>]
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let AsFSharpResult(x: RustyOptions.Result<'a, 'err>) =
+        match x.IsOk() with
+        | (true, value) -> Ok value
+        | _ -> Error(x.UnwrapErr())
+
+module Option =
+
+    /// Converts a RustyOptions Option into an F# Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let ofRustyOption (x: RustyOptions.Option<'a>) =
+        match x.IsSome() with
+        | (true, value) -> Some value
+        | _ -> None
+
+    /// Converts an F# Option into a RustyOptions Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let toRustyOption (x: 'a option) =
+        match x with
+        | Some(value) -> RustyOptions.Option.Some(value)
+        | _ -> RustyOptions.Option.None<'a>()
+
+module ValueOption =
+
+    /// Converts a RustyOptions Option into an F# ValueOption.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let ofRustyOption (x: RustyOptions.Option<'a>) =
+        match x.IsSome() with
+        | (true, value) -> ValueSome value
+        | _ -> ValueNone
+
+    /// Converts an F# Option into a RustyOptions Option.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let toRustyOption (x: 'a voption) =
+        match x with
+        | ValueSome(value) -> RustyOptions.Option.Some(value)
+        | _ -> RustyOptions.Option.None<'a>()
+
+module Result =
+
+    /// Converts a RustyOptions Result into an F# Result.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let ofRustyResult (x: RustyOptions.Result<'a, 'err>) =
+        match x.IsOk() with
+        | (true, value) -> Ok value
+        | _ -> Error(x.UnwrapErr())
+
+    /// Converts an F# Result into a RustyOptions result.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let toRustyResult (x: Result<'a, 'err>) =
+        match x with
+        | Ok(value) -> RustyOptions.Result.Ok<'a, 'err>(value)
+        | Error(err) -> RustyOptions.Result.Err<'a, 'err>(err)

--- a/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
+++ b/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
@@ -9,7 +9,7 @@
     <PackageId>RustyOptions.FSharp</PackageId>
     <Authors>Joel Mueller</Authors>
     <Company></Company>
-    <PackageDescription>Option and Result types for C#, inspired by Rust</PackageDescription>
+    <PackageDescription>F# support for RustyOptions</PackageDescription>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/jtmueller/RustyOptions</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
+++ b/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>RustyOptions.FSharp</AssemblyName>
+    <Version>0.6.0</Version>
+    <ReleaseVersion>0.6.0</ReleaseVersion>
+    <PackageId>RustyOptions.FSharp</PackageId>
+    <Authors>Joel Mueller</Authors>
+    <Company></Company>
+    <PackageDescription>Option and Result types for C#, inspired by Rust</PackageDescription>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/jtmueller/RustyOptions</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RustyOptions\RustyOptions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/RustyOptions.Tests/FSharpConversionTests.cs
+++ b/src/RustyOptions.Tests/FSharpConversionTests.cs
@@ -42,4 +42,32 @@ public sealed class FSharpConversionTests
         Assert.Equal(42, okFs.ResultValue);
         Assert.Equal("oops", errFs.ErrorValue);
     }
+
+#if NET7_0_OR_GREATER
+    [Fact]
+    public void CanConvertNumericOption()
+    {
+        var some = NumericOption.Some(42);
+        var none = NumericOption.None<int>();
+
+        var someFs = some.AsFSharpOption();
+        var noneFs = none.AsFSharpOption();
+
+        Assert.Equal(42, someFs.Value);
+        Assert.Throws<NullReferenceException>(() => noneFs.Value);
+    }
+
+    [Fact]
+    public void CanConvertNumericValueOption()
+    {
+        var some = NumericOption.Some(42);
+        var none = NumericOption.None<int>();
+
+        var someFs = some.AsFSharpValueOption();
+        var noneFs = none.AsFSharpValueOption();
+
+        Assert.Equal(42, someFs.Value);
+        Assert.True(noneFs.IsNone);
+    }
+#endif
 }

--- a/src/RustyOptions.Tests/FSharpConversionTests.cs
+++ b/src/RustyOptions.Tests/FSharpConversionTests.cs
@@ -1,0 +1,45 @@
+﻿using RustyOptions.FSharp;
+
+namespace RustyOptions.Tests;
+
+public sealed class FSharpConversionTests
+{
+    [Fact]
+    public void CanConvertOption()
+    {
+        var some = Option.Some(42);
+        var none = Option.None<int>();
+
+        var someFs = some.AsFSharpOption();
+        var noneFs = none.AsFSharpOption();
+
+        Assert.Equal(42, someFs.Value);
+        Assert.Throws<NullReferenceException>(() => noneFs.Value);
+    }
+
+    [Fact]
+    public void CanConvertValueOption()
+    {
+        var some = Option.Some(42);
+        var none = Option.None<int>();
+
+        var someFs = some.AsFSharpValueOption();
+        var noneFs = none.AsFSharpValueOption();
+
+        Assert.Equal(42, someFs.Value);
+        Assert.True(noneFs.IsNone);
+    }
+
+    [Fact]
+    public void CanConvertResult()
+    {
+        var ok = Result.Ok(42);
+        var err = Result.Err<int>("oops");
+
+        var okFs = ok.AsFSharpResult();
+        var errFs = err.AsFSharpResult();
+
+        Assert.Equal(42, okFs.ResultValue);
+        Assert.Equal("oops", errFs.ErrorValue);
+    }
+}

--- a/src/RustyOptions.Tests/RustyOptions.Tests.csproj
+++ b/src/RustyOptions.Tests/RustyOptions.Tests.csproj
@@ -8,7 +8,7 @@
     <LangVersion>11</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyName>RustyOptions.Tests</AssemblyName>
-    <ReleaseVersion>0.5.0</ReleaseVersion>
+    <ReleaseVersion>0.6.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,5 +30,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RustyOptions\RustyOptions.csproj" />
+    <ProjectReference Include="..\RustyOptions.FSharp\RustyOptions.FSharp.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/RustyOptions.sln
+++ b/src/RustyOptions.sln
@@ -15,6 +15,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\codecov.yml = ..\codecov.yml
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RustyOptions.FSharp", "RustyOptions.FSharp\RustyOptions.FSharp.fsproj", "{0BC912B8-D467-4267-812A-EBAB84AAFEC0}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RustyOptions.FSharp.Tests", "RustyOptions.FSharp.Tests\RustyOptions.FSharp.Tests.fsproj", "{C80F0600-4305-4B44-9534-8B38EDDBE4DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,9 +36,17 @@ Global
 		{B261E3E2-0462-4F28-9C4D-5D9809D55B83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B261E3E2-0462-4F28-9C4D-5D9809D55B83}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B261E3E2-0462-4F28-9C4D-5D9809D55B83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BC912B8-D467-4267-812A-EBAB84AAFEC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BC912B8-D467-4267-812A-EBAB84AAFEC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BC912B8-D467-4267-812A-EBAB84AAFEC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BC912B8-D467-4267-812A-EBAB84AAFEC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C80F0600-4305-4B44-9534-8B38EDDBE4DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C80F0600-4305-4B44-9534-8B38EDDBE4DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C80F0600-4305-4B44-9534-8B38EDDBE4DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C80F0600-4305-4B44-9534-8B38EDDBE4DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = Option and Result types for C#, inspired by Rust
-		version = 0.5.0
+		version = 0.6.0
 	EndGlobalSection
 EndGlobal

--- a/src/RustyOptions/RustyOptions.csproj
+++ b/src/RustyOptions/RustyOptions.csproj
@@ -7,8 +7,8 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <LangVersion>11</LangVersion>
     <AssemblyName>RustyOptions</AssemblyName>
-    <Version>0.5.0</Version>
-    <ReleaseVersion>0.5.0</ReleaseVersion>
+    <Version>0.6.0</Version>
+    <ReleaseVersion>0.6.0</ReleaseVersion>
     <PackageId>RustyOptions</PackageId>
     <Authors>Joel Mueller</Authors>
     <Company></Company>
@@ -37,6 +37,6 @@
 
   <ItemGroup>
     <Folder Include="Async\" />
-    <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds an optional package to support conversion between RustyOptions and F# option and result types.

Resolves #14 