### PR TITLE
Removing implicit FSharp.Core reference

### DIFF
--- a/src/RustyOptions.FSharp.Tests/RustyOptions.FSharp.Tests.fsproj
+++ b/src/RustyOptions.FSharp.Tests/RustyOptions.FSharp.Tests.fsproj
@@ -27,6 +27,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Remove="FSharp.Core" />
+    <PackageReference Include="FSharp.Core" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
+++ b/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
@@ -27,4 +27,9 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Remove="FSharp.Core" />
+    <PackageReference Include="FSharp.Core" Version="7.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Explicitly referencing the latest release version of FSharp.Core

Resolves #16 