### PR TITLE
Adding a Unit type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Option and Result types for C#, inspired by Rust
 [![CI](https://github.com/jtmueller/RustyOptions/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/jtmueller/RustyOptions/actions/workflows/build-and-test.yml) 
 [![CodeQL](https://github.com/jtmueller/RustyOptions/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/jtmueller/RustyOptions/actions/workflows/codeql-analysis.yml) 
 [![codecov](https://codecov.io/gh/jtmueller/RustyOptions/branch/main/graph/badge.svg?token=M81EJH4ZEI)](https://codecov.io/gh/jtmueller/RustyOptions)
+[![NuGet](https://buildstats.info/nuget/RustyOptions)](https://www.nuget.org/packages/RustyOptions/)
 
 ```
 dotnet add package RustyOptions
@@ -173,8 +174,10 @@ For performance and convenience:
 
 ## FAQ
 
-  - This library only supports .NET 6 and above. What about .NET Framework?
+  - This library only supports .NET 6 and above. What about .NET Framework? .NET 5? .NET Core 3.1?
     - You may want to consider the [Optional](https://github.com/nlkl/Optional) library for legacy framework support.
+    - .NET Core 3.1 and .NET 5 are not supported because as of this writing they are no longer supported by Microsoft.
+      However, if these runtimes are important to you, we welcome pull requests.
   - Why create this library if [Optional](https://github.com/nlkl/Optional) already exists?
     - I prefer the Rust Option/Result API methods and wanted to replicate those in C#.
     - I wanted to take advantage of modern .NET features like `ISpanParsable<T>` and `INumber<T>`.

--- a/src/RustyOptions.FSharp.Tests/RustyOptions.FSharp.Tests.fsproj
+++ b/src/RustyOptions.FSharp.Tests/RustyOptions.FSharp.Tests.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>0.6.1</ReleaseVersion>
+    <ReleaseVersion>0.7.0</ReleaseVersion>
     <AssemblyName>RustyOptions.FSharp.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/src/RustyOptions.FSharp.Tests/Tests.fs
+++ b/src/RustyOptions.FSharp.Tests/Tests.fs
@@ -70,6 +70,28 @@ let ``Can convert Result with module functions`` () =
     Assert.Equal(ok, okConverted)
     Assert.Equal(err, errConverted)
 
+[<Fact>]
+let ``Can convert Unit`` () =
+    let rustyUnit = RustyOptions.Unit.Default;
+    let fsUnit = ()
+
+    Assert.Equal(fsUnit, rustyUnit.AsFSharpUnit());
+    Assert.Equal(rustyUnit, fsUnit.AsRustyUnit());
+
+[<Fact>]
+let ``Can convert Unit Result`` () =
+    let rustyOk = RustyOptions.Result.Ok<RustyOptions.Unit, string>(RustyOptions.Unit.Default)
+    let rustyErr = RustyOptions.Result.Err<RustyOptions.Unit, string>("oops")
+
+    let fsOk = Ok ()
+    let fsErr = Error("oops")
+
+    Assert.Equal(fsOk, rustyOk |> Result.ofRustyUnitResult)
+    Assert.Equal(fsErr, rustyErr |> Result.ofRustyUnitResult)
+
+    Assert.Equal(rustyOk, fsOk |> Result.toRustyUnitResult)
+    Assert.Equal(rustyErr, fsErr |> Result.toRustyUnitResult)
+
 #if NET7_0_OR_GREATER
 [<Fact>]
 let ``Can convert NumericOption with extension methods`` () =

--- a/src/RustyOptions.FSharp/Library.fs
+++ b/src/RustyOptions.FSharp/Library.fs
@@ -4,7 +4,6 @@ open System.Runtime.CompilerServices
 
 /// This module provides F# extension methods on RustyOptions types.
 [<AutoOpen>]
-[<Extension>]
 module TypeExtensions =
 
     type RustyOptions.Option<'a> with
@@ -85,7 +84,6 @@ module CSharpTypeExtensions =
         match x.IsOk() with
         | (true, value) -> Ok value
         | _ -> Error(x.UnwrapErr())
-
 
     /// Converts a RustyOptions Unit Result into an F# unit Result.
     [<Extension>]

--- a/src/RustyOptions.FSharp/Library.fs
+++ b/src/RustyOptions.FSharp/Library.fs
@@ -29,6 +29,11 @@ module TypeExtensions =
             | (true, value) -> Ok value
             | _ -> Error(x.UnwrapErr())
 
+    type RustyOptions.Unit with
+        /// Converts a RustyOptions Unit into an F# unit.
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        member x.AsFSharpUnit() = ()
+
 #if NET7_0_OR_GREATER
     type RustyOptions.NumericOption<'a when 'a : struct and 'a :> System.ValueType and 'a : (new : unit -> 'a) and 'a :> System.Numerics.INumber<'a>> with
 
@@ -74,6 +79,11 @@ module CSharpTypeExtensions =
         match x.IsOk() with
         | (true, value) -> Ok value
         | _ -> Error(x.UnwrapErr())
+
+    /// Converts a RustyOptions Unit into an F# unit.
+    [<Extension>]
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let AsFSharpUnit(x: RustyOptions.Unit) = ()
 
 #if NET7_0_OR_GREATER
 /// This module provides C# extension methods on RustyOptions numeric types.
@@ -176,3 +186,17 @@ module Result =
         match x with
         | Ok(value) -> RustyOptions.Result.Ok<'a, 'err>(value)
         | Error(err) -> RustyOptions.Result.Err<'a, 'err>(err)
+
+    /// Converts a RustyOptions Unit Result into an F# unit Result.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let ofRustyUnitResult (x: RustyOptions.Result<RustyOptions.Unit, 'err>) =
+        match x.IsOk() with
+        | (true, _) -> Ok ()
+        | _ -> Error(x.UnwrapErr())
+
+    /// Converts an F# unit Result into a RustyOptions Unit Result.
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let toRustyUnitResult (x: Result<unit, 'err>) =
+        match x with
+        | Ok(_) -> RustyOptions.Result.Ok<RustyOptions.Unit, 'err>(RustyOptions.Unit.Default)
+        | Error(err) -> RustyOptions.Result.Err<RustyOptions.Unit, 'err>(err)

--- a/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
+++ b/src/RustyOptions.FSharp/RustyOptions.FSharp.fsproj
@@ -4,8 +4,8 @@
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>RustyOptions.FSharp</AssemblyName>
-    <Version>0.6.1</Version>
-    <ReleaseVersion>0.6.1</ReleaseVersion>
+    <Version>0.7.0</Version>
+    <ReleaseVersion>0.7.0</ReleaseVersion>
     <PackageId>RustyOptions.FSharp</PackageId>
     <Authors>Joel Mueller</Authors>
     <Company></Company>

--- a/src/RustyOptions.Tests/FSharpConversionTests.cs
+++ b/src/RustyOptions.Tests/FSharpConversionTests.cs
@@ -43,6 +43,19 @@ public sealed class FSharpConversionTests
         Assert.Equal("oops", errFs.ErrorValue);
     }
 
+    [Fact]
+    public void CanConvertUnitResult()
+    {
+        var ok = Result.Ok(Unit.Default);
+        var err = Result.Err<Unit>("oops");
+
+        var okFs = ok.AsFSharpUnitResult();
+        var errFs = err.AsFSharpUnitResult();
+
+        Assert.True(okFs.IsOk);
+        Assert.Equal("oops", errFs.ErrorValue);
+    }
+
 #if NET7_0_OR_GREATER
     [Fact]
     public void CanConvertNumericOption()

--- a/src/RustyOptions.Tests/JsonSerializationTests.cs
+++ b/src/RustyOptions.Tests/JsonSerializationTests.cs
@@ -256,6 +256,8 @@ public class JsonSerializationTests
         var desOk = JsonSerializer.Deserialize<Result<Unit, string>>("""{"ok":null}""");
         var desErr = JsonSerializer.Deserialize<Result<Unit, string>>("""{"err":"oops"}""");
 
+        _ = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Result<Unit, string>>("""{"ok":1}"""));
+
         Assert.Equal(ok, desOk);
         Assert.Equal(err, desErr);
     }

--- a/src/RustyOptions.Tests/JsonSerializationTests.cs
+++ b/src/RustyOptions.Tests/JsonSerializationTests.cs
@@ -216,6 +216,50 @@ public class JsonSerializationTests
         Assert.Equal(ResultErr, serialized);
     }
 
+    [Fact]
+    public void CanSerializeUnit()
+    {
+        Unit unit;
+
+        var serialized = JsonSerializer.Serialize(unit);
+
+        Assert.Equal("null", serialized);
+    }
+
+    [Fact]
+    public void CanDeserializeUnit()
+    {
+        var deserialized = JsonSerializer.Deserialize<Unit>("null");
+
+        Assert.Equal(Unit.Default, deserialized);
+    }
+
+    [Fact]
+    public void CanSerializeUnitResult()
+    {
+        var ok = Result.Ok(Unit.Default);
+        var err = Result.Err<Unit>("oops");
+
+        var serOk = JsonSerializer.Serialize(ok);
+        var serErr = JsonSerializer.Serialize(err);
+
+        Assert.Equal("""{"ok":null}""", serOk);
+        Assert.Equal("""{"err":"oops"}""", serErr);
+    }
+
+    [Fact]
+    public void CanDeserializeUnitResult()
+    {
+        var ok = Result.Ok(Unit.Default);
+        var err = Result.Err<Unit>("oops");
+
+        var desOk = JsonSerializer.Deserialize<Result<Unit, string>>("""{"ok":null}""");
+        var desErr = JsonSerializer.Deserialize<Result<Unit, string>>("""{"err":"oops"}""");
+
+        Assert.Equal(ok, desOk);
+        Assert.Equal(err, desErr);
+    }
+
     private const string OptionsAllSome = $$"""
         {"foo":42,"bar":17,"name":"Frank","lastUpdated":"{{DtoString}}"}
         """;

--- a/src/RustyOptions.Tests/RustyOptions.Tests.csproj
+++ b/src/RustyOptions.Tests/RustyOptions.Tests.csproj
@@ -8,7 +8,7 @@
     <LangVersion>11</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyName>RustyOptions.Tests</AssemblyName>
-    <ReleaseVersion>0.6.1</ReleaseVersion>
+    <ReleaseVersion>0.7.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RustyOptions.Tests/UnitTests.cs
+++ b/src/RustyOptions.Tests/UnitTests.cs
@@ -1,0 +1,6 @@
+﻿namespace RustyOptions.Tests;
+
+public sealed class UnitTests
+{
+
+}

--- a/src/RustyOptions.Tests/UnitTests.cs
+++ b/src/RustyOptions.Tests/UnitTests.cs
@@ -2,5 +2,60 @@
 
 public sealed class UnitTests
 {
+    [Fact]
+    public void CanCreateAndCompare()
+    {
+        var u1 = Unit.Default;
+        Unit u2;
 
+        Assert.True(u1.Equals(u2));
+        Assert.True(u1.Equals((object)u2));
+        Assert.False(u1.Equals(""));
+        Assert.Equal(0, u1.GetHashCode());
+
+        Assert.True(u1 == u2);
+        Assert.False(u1 != u2);
+        Assert.False(u1 < u2);
+        Assert.True(u1 <= u2);
+        Assert.False(u1 > u2);
+        Assert.True(u1 >= u2);
+        Assert.Equal(u1, u1 + u2);
+
+        Assert.Equal(0, u1.CompareTo(u2));
+    }
+
+    [Fact]
+    public void CanConvertToString()
+    {
+        var u1 = Unit.Default;
+
+        Assert.Equal("()", u1.ToString());
+        Assert.Equal("()", u1.ToString(null, null));
+
+        Span<char> buffer = stackalloc char[10];
+        var success = u1.TryFormat(buffer, out int written, ReadOnlySpan<char>.Empty, null);
+
+        Assert.True(success);
+        Assert.Equal(2, written);
+        Assert.True(buffer[..written].SequenceEqual("()"));
+
+        buffer = Span<char>.Empty;
+        success = u1.TryFormat(buffer, out written, ReadOnlySpan<char>.Empty, null);
+
+        Assert.False(success);
+        Assert.Equal(0, written);
+    }
+
+    [Fact]
+    public void CanConvertToValueTuple()
+    {
+        Unit u1;
+        ValueTuple vt1;
+
+        Unit u2 = vt1;
+        ValueTuple vt2 = u1;
+
+        Assert.Equal(vt1, vt2);
+        Assert.Equal(u1, u2);
+    }
 }

--- a/src/RustyOptions.sln
+++ b/src/RustyOptions.sln
@@ -47,6 +47,6 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = Option and Result types for C#, inspired by Rust
-		version = 0.6.1
+		version = 0.7.0
 	EndGlobalSection
 EndGlobal

--- a/src/RustyOptions/RustyOptions.csproj
+++ b/src/RustyOptions/RustyOptions.csproj
@@ -7,8 +7,8 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <LangVersion>11</LangVersion>
     <AssemblyName>RustyOptions</AssemblyName>
-    <Version>0.6.1</Version>
-    <ReleaseVersion>0.6.1</ReleaseVersion>
+    <Version>0.7.0</Version>
+    <ReleaseVersion>0.7.0</ReleaseVersion>
     <PackageId>RustyOptions</PackageId>
     <Authors>Joel Mueller</Authors>
     <Company></Company>

--- a/src/RustyOptions/Unit.cs
+++ b/src/RustyOptions/Unit.cs
@@ -1,0 +1,105 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace RustyOptions;
+
+/// <summary>
+/// A unit type is a type that allows only one value and holds no information. It can be used
+/// as a placeholder in a <see cref="Result{T, TErr}"/> that returns no data.
+/// </summary>
+/// <remarks>
+/// <para>The unit type is similar to <c>void</c> in C#, except that it is an actual value that
+/// can be returned, and a type that can be used as a generic type parameters.</para>
+/// <para>For RustyOptions, the main use of this type is to allow for <c>Result</c>-returning methods
+/// that do not return a value, but might return an error: <c>Result&lt;Unit, TErr&gt;</c></para>
+/// </remarks>
+[Serializable]
+[JsonConverter(typeof(UnitJsonConverter))]
+public readonly struct Unit : IEquatable<Unit>, IComparable<Unit>, ISpanFormattable
+{
+    /// <summary>
+    /// Returns the <c>Unit</c> instance.
+    /// </summary>
+    public static readonly Unit Default = default;
+
+    /// <inheritdoc />
+    public int CompareTo(Unit other) => 0;
+
+    /// <inheritdoc />
+    public bool Equals(Unit other) => true;
+
+    /// <inheritdoc />
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Unit;
+
+    /// <inheritdoc />
+    public override int GetHashCode() => 0;
+
+    /// <inheritdoc />
+    public override string ToString() => "()";
+
+    /// <inheritdoc />
+    public string ToString(string? format, IFormatProvider? formatProvider) => "()";
+
+    /// <inheritdoc />
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        if ("()".AsSpan().TryCopyTo(destination))
+        {
+            charsWritten = 2;
+            return true;
+        }
+
+        charsWritten = 0;
+        return false;
+    }
+
+#pragma warning disable IDE0060 // Remove unused parameter
+
+    /// <summary>
+    /// The equality operator for <c>Unit</c>. Always returns <c>true</c>.
+    /// </summary>
+    public static bool operator ==(Unit left, Unit right) => true;
+
+    /// <summary>
+    /// The inequality operator for <c>Unit</c>. Always returns <c>false</c>.
+    /// </summary>
+    public static bool operator !=(Unit left, Unit right) => false;
+
+    /// <summary>
+    /// The less-than operator for <c>Unit</c>. Always returns <c>false</c>.
+    /// </summary>
+    public static bool operator <(Unit left, Unit right) => false;
+
+    /// <summary>
+    /// The less-than-or-equals operator for <c>Unit</c>. Always returns <c>true</c>.
+    /// </summary>
+    public static bool operator <=(Unit left, Unit right) => true;
+
+    /// <summary>
+    /// The greater-than operator for <c>Unit</c>. Always returns <c>false</c>.
+    /// </summary>
+    public static bool operator >(Unit left, Unit right) => false;
+
+    /// <summary>
+    /// The greater-than-or-equal operator for <c>Unit</c>. Always returns <c>true</c>.
+    /// </summary>
+    public static bool operator >=(Unit left, Unit right) => true;
+
+    /// <summary>
+    /// The addition operator for <c>Unit</c>.
+    /// </summary>
+    public static Unit operator +(Unit left, Unit right) => default;
+
+    /// <summary>
+    /// Provides implicit conversion between <c>Unit</c> and the empty <c>ValueTuple</c>.
+    /// </summary>
+    public static implicit operator ValueTuple(Unit unit) => default;
+
+    /// <summary>
+    /// Provides implicit conversion between <c>Unit</c> and the empty <c>ValueTuple</c>.
+    /// </summary>
+    public static implicit operator Unit(ValueTuple tuple) => default;
+
+#pragma warning restore IDE0060 // Remove unused parameter
+
+}

--- a/src/RustyOptions/Unit.cs
+++ b/src/RustyOptions/Unit.cs
@@ -20,7 +20,7 @@ public readonly struct Unit : IEquatable<Unit>, IComparable<Unit>, ISpanFormatta
     /// <summary>
     /// Returns the <c>Unit</c> instance.
     /// </summary>
-    public static readonly Unit Default = default;
+    public static readonly Unit Default;
 
     /// <inheritdoc />
     public int CompareTo(Unit other) => 0;

--- a/src/RustyOptions/UnitJsonConverter.cs
+++ b/src/RustyOptions/UnitJsonConverter.cs
@@ -8,6 +8,9 @@ namespace RustyOptions;
 /// </summary>
 public sealed class UnitJsonConverter : JsonConverter<Unit>
 {
+    /// <summary>
+    /// Creates a new instance of UnitJsonConverter.
+    /// </summary>
     public UnitJsonConverter()
     {
     }

--- a/src/RustyOptions/UnitJsonConverter.cs
+++ b/src/RustyOptions/UnitJsonConverter.cs
@@ -11,14 +11,14 @@ public sealed class UnitJsonConverter : JsonConverter<Unit>
     /// <summary>
     /// Creates a new instance of UnitJsonConverter.
     /// </summary>
-    public UnitJsonConverter()
+    public UnitJsonConverter() : base()
     {
     }
 
     /// <inheritdoc/>
     public override Unit Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType != JsonTokenType.Null || !reader.Read())
+        if (reader.TokenType != JsonTokenType.Null)
             throw new JsonException();
 
         return default;
@@ -30,4 +30,3 @@ public sealed class UnitJsonConverter : JsonConverter<Unit>
         writer.WriteNullValue();
     }
 }
-

--- a/src/RustyOptions/UnitJsonConverter.cs
+++ b/src/RustyOptions/UnitJsonConverter.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RustyOptions;
+
+/// <summary>
+/// Supports <see cref="Unit"/> in System.Text.Json serialization.
+/// </summary>
+public sealed class UnitJsonConverter : JsonConverter<Unit>
+{
+    public UnitJsonConverter()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override Unit Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.Null || !reader.Read())
+            throw new JsonException();
+
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, Unit value, JsonSerializerOptions options)
+    {
+        writer.WriteNullValue();
+    }
+}
+


### PR DESCRIPTION
A Unit type is necessary for Result-returning methods that might fail, but do not return a value if they succeed. This is because the C# `void` type cannot be a generic type parameter or a value.

Resolves #21 